### PR TITLE
feat(security): Implementa o vínculo de dados por usuário

### DIFF
--- a/app/Console/Commands/AssignOrphanDataToUser.php
+++ b/app/Console/Commands/AssignOrphanDataToUser.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\Entry;
+use App\Models\Output;
 use App\Models\People;
 use App\Models\User;
 use Illuminate\Console\Command;
@@ -28,17 +29,17 @@ class AssignOrphanDataToUser extends Command
      */
     public function handle()
     {
-        $userId = $this->ask('Qual È o ID do usu·rio que deve se tornar o dono dos registros existentes?');
+        $userId = $this->ask('Qual √© o ID do usu√°rio que deve se tornar o dono dos registros existentes?');
 
         if (!is_numeric($userId) || !$user = User::find($userId)) {
-            $this->error("Nenhum usu·rio encontrado com o ID: {$userId}. OperaÁ„o cancelada.");
+            $this->error("Nenhum usu√°rio encontrado com o ID: {$userId}. Opera√ß√£o cancelada.");
             return 1;
         }
 
-        $this->info("Usu·rio '{$user->name}' (ID: {$user->id}) selecionado.");
+        $this->info("Usu√°rio '{$user->name}' (ID: {$user->id}) selecionado.");
 
-        if (!$this->confirm('VocÍ confirma que deseja atribuir todos os registros sem dono a este usu·rio?', true)) {
-            $this->info('OperaÁ„o cancelada pelo usu·rio.');
+        if (!$this->confirm('Voc√™ confirma que deseja atribuir todos os registros sem dono a este usu√°rio?', true)) {
+            $this->info('Opera√ß√£o cancelada pelo usu√°rio.');
             return 1;
         }
 
@@ -51,10 +52,10 @@ class AssignOrphanDataToUser extends Command
         $this->info("{$entriesCount} registros atualizados em 'entries'.");
 
         $this->info('Atualizando tabela "outputs"...');
-        $outputsCount = Entry::whereNull('user_id')->update(['user_id' => $userId]);
+        $outputsCount = Output::whereNull('user_id')->update(['user_id' => $userId]);
         $this->info("{$outputsCount} registros atualizados em 'outputs'.");
 
-        $this->info("\nOperaÁ„o concluÌda com sucesso!");
+        $this->info("\nOpera√ß√£o conclu√≠da com sucesso!");
 
         return 0;
     }

--- a/app/Console/Commands/AssignOrphanDataToUser.php
+++ b/app/Console/Commands/AssignOrphanDataToUser.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Entry;
+use App\Models\People;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class AssignOrphanDataToUser extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:assign-orphan-data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Assigns orphan records in people and entries tables to a specified user.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $userId = $this->ask('Qual é o ID do usuário que deve se tornar o dono dos registros existentes?');
+
+        if (!is_numeric($userId) || !$user = User::find($userId)) {
+            $this->error("Nenhum usuário encontrado com o ID: {$userId}. Operação cancelada.");
+            return 1;
+        }
+
+        $this->info("Usuário '{$user->name}' (ID: {$user->id}) selecionado.");
+
+        if (!$this->confirm('Você confirma que deseja atribuir todos os registros sem dono a este usuário?', true)) {
+            $this->info('Operação cancelada pelo usuário.');
+            return 1;
+        }
+
+        $this->info('Atualizando tabela "people"...');
+        $peopleCount = People::whereNull('user_id')->update(['user_id' => $userId]);
+        $this->info("{$peopleCount} registros atualizados em 'people'.");
+
+        $this->info('Atualizando tabela "entries"...');
+        $entriesCount = Entry::whereNull('user_id')->update(['user_id' => $userId]);
+        $this->info("{$entriesCount} registros atualizados em 'entries'.");
+
+        $this->info('Atualizando tabela "outputs"...');
+        $outputsCount = Entry::whereNull('user_id')->update(['user_id' => $userId]);
+        $this->info("{$outputsCount} registros atualizados em 'outputs'.");
+
+        $this->info("\nOperação concluída com sucesso!");
+
+        return 0;
+    }
+}

--- a/app/Filament/Resources/EntryResource.php
+++ b/app/Filament/Resources/EntryResource.php
@@ -45,7 +45,7 @@ class EntryResource extends Resource
                 Forms\Components\DateTimePicker::make('entry_date')->label('Data da entrada'),
                 Forms\Components\Select::make('people_id')
                     ->options(
-                        People::query()->pluck('full_name', 'id')->toArray()
+                        People::query()->where('user_id', auth()->id())->pluck('full_name', 'id')->toArray()
                     )
                     ->label('Quem recebeu ?')
                     ->hint('Pessoa que recebeu o valor.')
@@ -112,5 +112,10 @@ class EntryResource extends Resource
             'create' => Pages\CreateEntry::route('/create'),
             'edit' => Pages\EditEntry::route('/{record}/edit'),
         ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('user_id', auth()->id());
     }
 }

--- a/app/Filament/Resources/EntryResource/Pages/CreateEntry.php
+++ b/app/Filament/Resources/EntryResource/Pages/CreateEntry.php
@@ -10,4 +10,11 @@ class CreateEntry extends CreateRecord
 {
     protected static string $resource = EntryResource::class;
     protected static bool $canCreateAnother = false;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['user_id'] = auth()->id();
+
+        return $data;
+    }
 }

--- a/app/Filament/Resources/OutputResource.php
+++ b/app/Filament/Resources/OutputResource.php
@@ -11,6 +11,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class OutputResource extends Resource
 {
@@ -53,7 +54,7 @@ class OutputResource extends Resource
                 Forms\Components\DateTimePicker::make('output_date')->label('Data da saída'),
                 Forms\Components\Select::make('people_id')
                     ->options(
-                        People::query()->pluck('full_name', 'id')->toArray()
+                        People::query()->where('user_id', auth()->id())->pluck('full_name', 'id')->toArray()
                     )
                     ->label('Quem gastou ?')
                     ->hint('Pessoa que gastou o valor.')
@@ -120,5 +121,10 @@ class OutputResource extends Resource
             'create' => Pages\CreateOutput::route('/create'),
             'edit' => Pages\EditOutput::route('/{record}/edit'),
         ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('user_id', auth()->id());
     }
 }

--- a/app/Filament/Resources/OutputResource/Pages/CreateOutput.php
+++ b/app/Filament/Resources/OutputResource/Pages/CreateOutput.php
@@ -25,4 +25,10 @@ class CreateOutput extends CreateRecord
         ]);
     }
 
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['user_id'] = auth()->id();
+
+        return $data;
+    }
 }

--- a/app/Filament/Resources/PeopleResource.php
+++ b/app/Filament/Resources/PeopleResource.php
@@ -9,6 +9,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class PeopleResource extends Resource
 {
@@ -69,5 +70,10 @@ class PeopleResource extends Resource
             'create' => Pages\CreatePerson::route('/create'),
             'edit' => Pages\EditPerson::route('/{record}/edit'),
         ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('user_id', auth()->id());
     }
 }

--- a/app/Filament/Resources/PeopleResource/Pages/CreatePerson.php
+++ b/app/Filament/Resources/PeopleResource/Pages/CreatePerson.php
@@ -11,4 +11,11 @@ class CreatePerson extends CreateRecord
     protected static string $resource = PeopleResource::class;
 
     protected static bool $canCreateAnother = false;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['user_id'] = auth()->id();
+
+        return $data;
+    }
 }

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -67,7 +67,7 @@ class StatsOverview extends BaseWidget
                 'R$ ' . number_format($this->monthOtherValues(), 2, ',', '.')
             )
                 ->descriptionIcon('heroicon-m-arrow-trending-up')
-                ->description('Salário mês de ' . $currentMonth)
+                ->description('Outros valores mês de ' . $currentMonth)
                 ->descriptionColor('success')
                 ->color('success')
                 ->chart([1,1,1,1,1]),

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -76,12 +76,15 @@ class StatsOverview extends BaseWidget
 
     public function peopleName(int $id)
     {
-        return People::query()->find($id)->full_name ?? 'sem cadastro';
+        return People::query()
+            ->where('user_id', auth()->id())
+            ->find($id)->full_name ?? 'sem cadastro';
     }
 
     public function monthSalary(int $people = 1): float
     {
         return Entry::query()
+            ->where('user_id', auth()->id())
             ->when($this->filterDate()['month'] ?? null, fn ($query, $month) => $query->whereMonth('entry_date', '=', $month))
             ->when($this->filterDate()['year'] ?? null, fn ($query, $year) => $query->whereYear('entry_date', '=', $year))
             ->when('salario', fn ($query, $year) => $query->where('type', '=', 'salario'))
@@ -92,6 +95,7 @@ class StatsOverview extends BaseWidget
     public function monthOtherValues(): float
     {
         return Entry::query()
+            ->where('user_id', auth()->id())
             ->when($this->filterDate()['month'] ?? null, fn ($query, $month) => $query->whereMonth('entry_date', '=', $month))
             ->when($this->filterDate()['year'] ?? null, fn ($query, $year) => $query->whereYear('entry_date', '=', $year))
             ->when('outros', fn ($query, $year) => $query->whereIn('type', ['outros', 'bonificacoes']))
@@ -101,6 +105,7 @@ class StatsOverview extends BaseWidget
     public function totalEntriesForCurrentMonth()
     {
         $entries = Entry::query()
+            ->where('user_id', auth()->id())
             ->when($this->filterDate()['month'] ?? null, fn ($query, $month) => $query->whereMonth('entry_date', '=', $month))
             ->when($this->filterDate()['year'] ?? null, fn ($query, $year) => $query->whereYear('entry_date', '=', $year))
             ->sum('value');
@@ -113,6 +118,7 @@ class StatsOverview extends BaseWidget
     public function totalOutputsForCurrentMonth()
     {
         $outputs = Output::query()
+            ->where('user_id', auth()->id())
             ->when($this->filterDate()['month'] ?? null, fn ($query, $month) => $query->whereMonth('output_date', '=', $month))
             ->when($this->filterDate()['year'] ?? null, fn ($query, $year) => $query->whereYear('output_date', '=', $year))
             ->sum('value');

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -15,6 +15,7 @@ class Entry extends Model
         'value',
         'entry_date',
         'people_id',
+        'user_id',
     ];
 
     /**
@@ -23,5 +24,13 @@ class Entry extends Model
     public function people(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(People::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/Output.php
+++ b/app/Models/Output.php
@@ -15,6 +15,7 @@ class Output extends Model
         'value',
         'output_date',
         'people_id',
+        'user_id',
     ];
 
     /**
@@ -25,8 +26,13 @@ class Output extends Model
         return $this->belongsTo(People::class);
     }
 
-    public function historY(): \Illuminate\Database\Eloquent\Relations\HasMany
+    public function history(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(History::class);
+    }
+
+    public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/People.php
+++ b/app/Models/People.php
@@ -10,11 +10,17 @@ class People extends Model
     use HasFactory;
 
     protected $fillable = [
-      'full_name'
+        'full_name',
+        'user_id',
     ];
 
     public function histories(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(History::class);
+    }
+
+    public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -28,6 +28,7 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('/')
             ->login()
+            ->registration()
             ->colors([
                 'primary' => Color::Indigo,
             ])

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^8.2",
         "ariaieboy/filament-currency": "^1.4",
+        "doctrine/dbal": "^3.10",
         "filament/filament": "^3.2",
         "filament/widgets": "^3.2",
         "laravel/framework": "^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee53af1ed259af5e946d0c6549dd6bd0",
+    "content-hash": "4c2690e0c28cb8764a4ffe66d460cacb",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -676,134 +676,42 @@
             "time": "2022-10-27T11:44:00+00:00"
         },
         {
-            "name": "doctrine/cache",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/cache.git",
-                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/1ca8f21980e770095a31456042471a57bc4c68fb",
-                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/common": ">2.2,<2.4"
-            },
-            "require-dev": {
-                "cache/integration-tests": "dev-master",
-                "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psr/cache": "^1.0 || ^2.0 || ^3.0",
-                "symfony/cache": "^4.4 || ^5.4 || ^6",
-                "symfony/var-exporter": "^4.4 || ^5.4 || ^6"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
-            "homepage": "https://www.doctrine-project.org/projects/cache.html",
-            "keywords": [
-                "abstraction",
-                "apcu",
-                "cache",
-                "caching",
-                "couchdb",
-                "memcached",
-                "php",
-                "redis",
-                "xcache"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/cache/issues",
-                "source": "https://github.com/doctrine/cache/tree/2.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-05-20T20:07:39+00:00"
-        },
-        {
             "name": "doctrine/dbal",
-            "version": "3.8.3",
+            "version": "3.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "db922ba9436b7b18a23d1653a0b41ff2369ca41c"
+                "reference": "c6c16cf787eaba3112203dfcd715fa2059c62282"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/db922ba9436b7b18a23d1653a0b41ff2369ca41c",
-                "reference": "db922ba9436b7b18a23d1653a0b41ff2369ca41c",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c6c16cf787eaba3112203dfcd715fa2059c62282",
+                "reference": "c6c16cf787eaba3112203dfcd715fa2059c62282",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2",
-                "doctrine/cache": "^1.11|^2.0",
                 "doctrine/deprecations": "^0.5.3|^1",
                 "doctrine/event-manager": "^1|^2",
                 "php": "^7.4 || ^8.0",
                 "psr/cache": "^1|^2|^3",
                 "psr/log": "^1|^2|^3"
             },
+            "conflict": {
+                "doctrine/cache": "< 1.11"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "12.0.0",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/coding-standard": "13.0.1",
                 "fig/log-test": "^1",
                 "jetbrains/phpstorm-stubs": "2023.1",
-                "phpstan/phpstan": "1.10.58",
-                "phpstan/phpstan-strict-rules": "^1.5",
-                "phpunit/phpunit": "9.6.16",
-                "psalm/plugin-phpunit": "0.18.4",
-                "slevomat/coding-standard": "8.13.1",
-                "squizlabs/php_codesniffer": "3.9.0",
+                "phpstan/phpstan": "2.1.22",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "9.6.23",
+                "slevomat/coding-standard": "8.16.2",
+                "squizlabs/php_codesniffer": "3.13.1",
                 "symfony/cache": "^5.4|^6.0|^7.0",
-                "symfony/console": "^4.4|^5.4|^6.0|^7.0",
-                "vimeo/psalm": "4.30.0"
+                "symfony/console": "^4.4|^5.4|^6.0|^7.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -863,7 +771,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.8.3"
+                "source": "https://github.com/doctrine/dbal/tree/3.10.2"
             },
             "funding": [
                 {
@@ -879,7 +787,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-03T15:55:06+00:00"
+            "time": "2025-09-04T23:51:27+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -10314,12 +10222,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/database/migrations/2025_09_09_021729_add_user_id_to_people_entries_outputs_tables.php
+++ b/database/migrations/2025_09_09_021729_add_user_id_to_people_entries_outputs_tables.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->after('id')->constrained();
+        });
+
+        Schema::table('entries', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->after('id')->constrained();
+        });
+
+        Schema::table('outputs', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->after('id')->constrained();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+
+        Schema::table('entries', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+
+        Schema::table('outputs', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};


### PR DESCRIPTION
### Descrição

Salve !!!

Este PR implementa a funcionalidade de **vínculo de dados por usuário**. A partir de agora, cada usuário só poderá ver e gerenciar os dados que ele mesmo cadastrou, garantindo a privacidade e a integridade das informações.

---

### O que foi feito?

*   **Schema do Banco:**
    *   Adicionada a coluna `user_id` (nullable) às tabelas `entries`, `outputs` e `people`. A coluna foi criada como `nullable` para não quebrar a aplicação com os dados já existentes.

*   **Filament Resources:**
    *   **Listagens:** As consultas (`getEloquentQuery`) dos Resources `Entry`, `Output` e `People` foram atualizadas para filtrar os registros pelo `user_id` do usuário autenticado.
    *   **Formulários de Criação:** Os métodos `mutateFormDataBeforeCreate` agora associam automaticamente o `user_id` do usuário logado a cada novo registro.

*   **Dashboard Widgets:**
    *   As consultas nos widgets (`StatsOverview` e `LatestSpending`) foram ajustadas para incluir a cláusula `where('user_id', auth()->id())`, garantindo que os cards e estatísticas reflitam apenas os dados do usuário logado.

*   **Backfill de Dados (Recuperação):**
    *   Criado o comando Artisan `app:assign-orphan-data` para atribuir registros existentes (órfãos) a um usuário específico. Isso permite a migração de dados legados sem perda de informação.

---

### Como testar?

1.  Rode as migrações com `php artisan migrate`.
2.  Se você tiver dados antigos no banco (sem `user_id`), pode rodar o comando que criei: `sail artisan app:assign-orphan-data` ele vai te perguntar para qual ID de usuário você quer atribuir os dados "órfãos".
3. Cria um usuário novo e verifica se os dados que tu criou dele aparece para outros usuários, se não aparecer quer dizer que tá bombando kkkk (na minha maquina ta bombando viu !!!)
4. Já ajustei os filtros pros widgets da dashboard também.
    